### PR TITLE
PatientService and PatientRegistrationController review

### DIFF
--- a/ClinicManagement_proj/UI/Controllers/PatientRegistrationController.cs
+++ b/ClinicManagement_proj/UI/Controllers/PatientRegistrationController.cs
@@ -16,23 +16,50 @@ namespace ClinicManagement_proj.UI
 
 
         private readonly Panel panel;
-        private DataGridView dgvPatients => (DataGridView)panel.Controls["dgvRegPatients"];
-        private GroupBox grpPatientRegistration => (GroupBox)panel.Controls["grpPatientRegistration"];
-        private TextBox txtPatientId => (TextBox)grpPatientRegistration.Controls["txtPatientId"];
 
-        private TextBox txtPFName => (TextBox)grpPatientRegistration.Controls["txtPFName"];
-        private TextBox txtPLName => (TextBox)grpPatientRegistration.Controls["txtPLName"];
-        private TextBox txtMedicalNumber => (TextBox)grpPatientRegistration.Controls["txtMedicalNumber"];
-        private DateTimePicker dateDoB => (DateTimePicker)grpPatientRegistration.Controls["dateDoB"];
-        private TextBox txtPPhone => (TextBox)grpPatientRegistration.Controls["txtPPhone"];
-        private TableLayoutPanel layoutPatientButtons => (TableLayoutPanel)grpPatientRegistration.Controls["layoutPatientButtons"];
-        private Button btnPatientCreate => (Button)layoutPatientButtons.Controls["btnPCreate"];
-        private Button btnPatientUpdate => (Button)layoutPatientButtons.Controls["btnPUpdate"];
-        private Button btnPatientCancel => (Button)layoutPatientButtons.Controls["btnPCancel"];
-        private Button btnPatientDelete => (Button)layoutPatientButtons.Controls["btnPDelete"];
-        private Button btnPatientDisplay => (Button)layoutPatientButtons.Controls["btnPDisplay"];
-        private Button btnPatientSearch => (Button)layoutPatientButtons.Controls["btnPSearch"];
-        private Button btnPatientRefresh => (Button)layoutPatientButtons.Controls["btnPRefresh"];
+        // TODO: SUGGESTION
+        // Okay, lets be honest, this is absolutely a mess.
+        // The way to go here would have been to create custom 'panel'-like user control classes.
+        // Like done here, you have to access the panel's controls the hard way and by using
+        // hard-coded strings. One typo, and weird error that doesn't seem to make sense. Refactor
+        // the control's name in the panel? It breaks down here too.
+        // Its also quite unefficient performance-wise since it adds a sh!tload of dereferencing-execution
+        // instructions in the background.
+        // So inorder to mitigate the hardcoded string accesses, I added null-coalescing instructions to throw
+        // more easily understandable errors than NullDereferenceException
+        private DataGridView dgvPatients => (DataGridView)panel.Controls["dgvRegPatients"] 
+            ?? throw new Exception("No control named [dgvRegPatients] found in panel controls collection.");
+        private GroupBox grpPatientRegistration => (GroupBox)panel.Controls["grpPatientRegistration"]
+            ?? throw new Exception("No control named [grpPatientRegistration] found in panel controls collection.");
+        private TextBox txtPatientId => (TextBox)grpPatientRegistration.Controls["txtPatientId"]
+            ?? throw new Exception("No control named [txtPatientId] found in grpPatientRegistration controls collection.");
+
+        private TextBox txtPFName => (TextBox)grpPatientRegistration.Controls["txtPFName"]
+            ?? throw new Exception("No control named [txtPFName] found in grpPatientRegistration controls collection.");
+        private TextBox txtPLName => (TextBox)grpPatientRegistration.Controls["txtPLName"]
+            ?? throw new Exception("No control named [txtPLName] found in grpPatientRegistration controls collection.");
+        private TextBox txtMedicalNumber => (TextBox)grpPatientRegistration.Controls["txtMedicalNumber"]
+            ?? throw new Exception("No control named [txtMedicalNumber] found in grpPatientRegistration controls collection.");
+        private DateTimePicker dateDoB => (DateTimePicker)grpPatientRegistration.Controls["dateDoB"]
+            ?? throw new Exception("No control named [dateDoB] found in grpPatientRegistration controls collection.");
+        private TextBox txtPPhone => (TextBox)grpPatientRegistration.Controls["txtPPhone"]
+            ?? throw new Exception("No control named [txtPPhone] found in grpPatientRegistration controls collection.");
+        private TableLayoutPanel layoutPatientButtons => (TableLayoutPanel)grpPatientRegistration.Controls["layoutPatientButtons"]
+            ?? throw new Exception("No control named [layoutPatientButtons] found in grpPatientRegistration controls collection.");
+        private Button btnPatientCreate => (Button)layoutPatientButtons.Controls["btnPCreate"]
+            ?? throw new Exception("No control named [btnPCreate] found in layoutPatientButtons controls collection.");
+        private Button btnPatientUpdate => (Button)layoutPatientButtons.Controls["btnPUpdate"]
+            ?? throw new Exception("No control named [btnPUpdate] found in layoutPatientButtons controls collection.");
+        private Button btnPatientCancel => (Button)layoutPatientButtons.Controls["btnPCancel"]
+            ?? throw new Exception("No control named [btnPCancel] found in layoutPatientButtons controls collection.");
+        private Button btnPatientDelete => (Button)layoutPatientButtons.Controls["btnPDelete"]
+            ?? throw new Exception("No control named [btnPDelete] found in layoutPatientButtons controls collection.");
+        private Button btnPatientDisplay => (Button)layoutPatientButtons.Controls["btnPDisplay"]
+            ?? throw new Exception("No control named [btnPDisplay] found in layoutPatientButtons controls collection.");
+        private Button btnPatientSearch => (Button)layoutPatientButtons.Controls["btnPSearch"]
+            ?? throw new Exception("No control named [btnPSearch] found in layoutPatientButtons controls collection.");
+        private Button btnPatientRefresh => (Button)layoutPatientButtons.Controls["btnPRefresh"]
+            ?? throw new Exception("No control named [btnPRefresh] found in layoutPatientButtons controls collection.");
 
         public Panel Panel => panel;
 
@@ -43,6 +70,7 @@ namespace ClinicManagement_proj.UI
 
         public void Initialize()
         {
+            
             btnPatientCreate.Click += new EventHandler(btnPatientCreate_Click);
             btnPatientUpdate.Click += new EventHandler(btnPatientUpdate_Click);
             btnPatientCancel.Click += new EventHandler(btnPatientCancel_Click);
@@ -95,16 +123,28 @@ namespace ClinicManagement_proj.UI
         {
             if (dgvPatients.CurrentRow != null)
             {
+                // TODO: SUGGESTION
+                // Since the data bound to the DGV is in the form of a List<PatientDTO>, its much more robust
+                // and efficient to access directly the underlaying PatientDTO bound to a row when the row is
+                // clicked upon.
+                // This will also be simpler when updating or deleting a 'selected' row.
 
-                int selectedUserId = (int)dgvPatients.CurrentRow.Cells["Id"].Value;
-                txtPatientId.Text = selectedUserId.ToString();
-                var user = patientService.Search(selectedUserId);
-                txtPFName.Text = user.FirstName;
-                txtPLName.Text = user.LastName;
-                dateDoB.Value = user.DateOfBirth;
-                txtMedicalNumber.Text = user.InsuranceNumber;
-                txtPPhone.Text = user.PhoneNumber;
+                PatientDTO clickedOnPatient = (PatientDTO) dgvPatients.CurrentRow.DataBoundItem;
+                txtPatientId.Text = clickedOnPatient.Id.ToString();
+                txtPFName.Text = clickedOnPatient.FirstName;
+                txtPLName.Text = clickedOnPatient.LastName;
+                dateDoB.Value = clickedOnPatient.DateOfBirth;
+                txtMedicalNumber.Text = clickedOnPatient.InsuranceNumber;
+                txtPPhone.Text = clickedOnPatient.PhoneNumber;
 
+                //int selectedUserId = (int)dgvPatients.CurrentRow.Cells["Id"].Value;
+                //txtPatientId.Text = selectedUserId.ToString();
+                //var user = patientService.Search(selectedUserId);
+                //txtPFName.Text = user.FirstName;
+                //txtPLName.Text = user.LastName;
+                //dateDoB.Value = user.DateOfBirth;
+                //txtMedicalNumber.Text = user.InsuranceNumber;
+                //txtPPhone.Text = user.PhoneNumber;
 
             }
         }
@@ -205,6 +245,29 @@ namespace ClinicManagement_proj.UI
         /// </summary>
         private void btnPatientUpdate_Click(object sender, EventArgs e)
         {
+            // TODO: SUGGESTION
+            // As for the DGV row-click, it would be wise to use the underlying PatientDTO
+            // object of the selected row than recreate a new one. Recreating a new one could lead
+            // to mismatches or duplicates in the DB, depending on the DB system used.
+            if (dgvPatients.CurrentRow != null) {
+
+                PatientDTO selectedPatient = (PatientDTO) dgvPatients.CurrentRow.DataBoundItem;
+                // Note: Id shouldnt be modifiable so i'm ignoring it here
+                selectedPatient.FirstName = txtPFName.Text;
+                selectedPatient.LastName = txtPLName.Text;
+                selectedPatient.DateOfBirth = dateDoB.Value;
+                selectedPatient.InsuranceNumber = txtMedicalNumber.Text;
+                selectedPatient.PhoneNumber = txtPPhone.Text;
+
+                patientService.UpdatePatient(selectedPatient);
+                dgvPatients.Refresh();
+
+            } else {
+                // Error message?
+            }
+
+
+            /*
             if (!int.TryParse(txtPatientId.Text, out int id))
             {
                 MessageBox.Show("Enter a valid ID.");
@@ -229,6 +292,8 @@ namespace ClinicManagement_proj.UI
 
             patientService.UpdatePatient(dto);
             LoadPatients();
+            */
+
             //ResetPatientForm();
 
         }
@@ -238,6 +303,26 @@ namespace ClinicManagement_proj.UI
         /// </summary>
         private void btnPatientDelete_Click(object sender, EventArgs e)
         {
+
+            // TODO: SUGGESTION
+            // As for the DGV row-click, it would be wise to use the underlying PatientDTO
+            // object of the selected row. This is consistent with the rest of the service behavior
+            // that receives new DTOs or modified DTOs.
+            if (dgvPatients.CurrentRow != null) {
+
+                PatientDTO selectedPatient = (PatientDTO) dgvPatients.CurrentRow.DataBoundItem;
+
+                _ = patientService.DeletePatient(selectedPatient);
+                dgvPatients.Refresh();
+                LoadPatients();
+                ResetPatientForm();
+
+            } else {
+                // Error message?
+            }
+
+
+            /*
             if (!int.TryParse(txtPatientId.Text, out int id))
             {
                 MessageBox.Show("Enter a valid ID.");
@@ -250,10 +335,11 @@ namespace ClinicManagement_proj.UI
                 return;
             }
 
-
             patientService.DeletePatient(id);
             LoadPatients();
             ResetPatientForm();
+            */
+
         }
 
         public void OnHide()


### PR DESCRIPTION
Bunch of small fixes, good practices suggestions and little additions to the 'patient' stack.

You can merge my fork's 'review' branch into the repos' own review branch without risking to affect your main/master that everyone normally use. I have tested the basic CRUD operations and they all currently work.

List of changed stuff (mostly):
- Added eager-loading of patients' appointments in service methods that 'get' patients
- Removed the unnecessary creation of DTO object copies in service methods.
- Added a PatientService.DeletePatient overload that receives a DTO instance instead of just an Id integer
- Made the basic CRUD methods of the PatientService return their created/modified/deleted DTO object (can be useful for follow-up operations)
- Added a more complex PatientService.Search overload that receives a string and returns a list of matching patients based on multiple fields/attributes
- Added typo-protecting null-coalescing exception throws to PatientManagementController to throw more understandable exceptions if the string name of a control has an error or is changed
- Replaced the DataGridView row/data access by id with access by underlying DTO instance that simplifies data handling and passing to Service methods.